### PR TITLE
add the `module.noParse` option for Elm files to suppress webpack warnings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
   module: {
     loaders: [
       {
-        test: /\.elm/,
+        test: /\.elm$/,
         loader: 'elm-simple-loader',
         include: path.join(__dirname, 'src'),
         exclude: /node_modules/
@@ -19,6 +19,7 @@ module.exports = {
         include: path.join(__dirname, 'src'),
         loader: 'file?name=[name].[ext]'
       }
-    ]
+    ],
+    noParse: [/.elm$/]
   }
 }


### PR DESCRIPTION
Fixes Webpack's warnings about precompiled JS being used on the end user side. Not ideal, but oh well.
